### PR TITLE
Updated to SDK 3.10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 25
-	buildToolsVersion "26.0.2"
+	compileSdkVersion 27
+	buildToolsVersion "27.0.3"
 
 	defaultConfig {
 		applicationId "com.jwplayer.opensourcedemo"
 		minSdkVersion 16
-		targetSdkVersion 25
+		targetSdkVersion 27
 		versionCode 1
 		versionName "1.0"
 	}
@@ -20,13 +20,14 @@ android {
 }
 
 dependencies {
-	compile fileTree(include: ['*.jar'], dir: 'libs')
-	testCompile 'junit:junit:4.12'
-	compile 'com.android.support:appcompat-v7:25.0.0'
-	compile 'com.android.support:design:25.0.0'
+	implementation fileTree(include: ['*.jar'], dir: 'libs')
+	testImplementation 'junit:junit:4.12'
+	implementation 'com.android.support:appcompat-v7:27.1.1'
+	implementation 'com.android.support:mediarouter-v7:27.1.1'
+	implementation 'com.android.support:design:27.1.1'
 
-	compile 'com.longtailvideo.jwplayer:jwplayer-core:+'
-	compile 'com.longtailvideo.jwplayer:jwplayer-common:+'
-//	compile 'com.longtailvideo.jwplayer:jwplayer-ima:+'        // Only required if using IMA features
-	compile 'com.longtailvideo.jwplayer:jwplayer-chromecast:+' // Only required if using Chromecast
+	implementation 'com.longtailvideo.jwplayer:jwplayer-core:3.1.0+58'
+	implementation 'com.longtailvideo.jwplayer:jwplayer-common:3.1.0+58'
+//	implementation 'com.longtailvideo.jwplayer:jwplayer-ima:3.1.0+58'        // Only required if using IMA features
+	implementation 'com.longtailvideo.jwplayer:jwplayer-chromecast:3.1.0+58' // Only required if using Chromecast
 }

--- a/app/src/main/java/com/jwplayer/opensourcedemo/JWEventHandler.java
+++ b/app/src/main/java/com/jwplayer/opensourcedemo/JWEventHandler.java
@@ -12,25 +12,41 @@ import com.longtailvideo.jwplayer.JWPlayerView;
 import com.longtailvideo.jwplayer.core.PlayerState;
 import com.longtailvideo.jwplayer.events.AdClickEvent;
 import com.longtailvideo.jwplayer.events.AdCompleteEvent;
+import com.longtailvideo.jwplayer.events.AdErrorEvent;
 import com.longtailvideo.jwplayer.events.AdImpressionEvent;
 import com.longtailvideo.jwplayer.events.AdPauseEvent;
 import com.longtailvideo.jwplayer.events.AdPlayEvent;
 import com.longtailvideo.jwplayer.events.AdSkippedEvent;
 import com.longtailvideo.jwplayer.events.AdTimeEvent;
+import com.longtailvideo.jwplayer.events.AudioTrackChangedEvent;
+import com.longtailvideo.jwplayer.events.AudioTracksEvent;
+import com.longtailvideo.jwplayer.events.BeforeCompleteEvent;
+import com.longtailvideo.jwplayer.events.BeforePlayEvent;
+import com.longtailvideo.jwplayer.events.BufferEvent;
+import com.longtailvideo.jwplayer.events.CaptionsChangedEvent;
+import com.longtailvideo.jwplayer.events.CaptionsListEvent;
+import com.longtailvideo.jwplayer.events.CompleteEvent;
 import com.longtailvideo.jwplayer.events.ControlsEvent;
+import com.longtailvideo.jwplayer.events.DisplayClickEvent;
 import com.longtailvideo.jwplayer.events.ErrorEvent;
-import com.longtailvideo.jwplayer.events.RelatedCloseEvent;
-import com.longtailvideo.jwplayer.events.RelatedOpenEvent;
-import com.longtailvideo.jwplayer.events.RelatedPlayEvent;
+import com.longtailvideo.jwplayer.events.FullscreenEvent;
+import com.longtailvideo.jwplayer.events.IdleEvent;
+import com.longtailvideo.jwplayer.events.LevelsChangedEvent;
+import com.longtailvideo.jwplayer.events.LevelsEvent;
+import com.longtailvideo.jwplayer.events.MetaEvent;
+import com.longtailvideo.jwplayer.events.MuteEvent;
+import com.longtailvideo.jwplayer.events.PauseEvent;
+import com.longtailvideo.jwplayer.events.PlayEvent;
+import com.longtailvideo.jwplayer.events.PlaylistCompleteEvent;
+import com.longtailvideo.jwplayer.events.PlaylistEvent;
+import com.longtailvideo.jwplayer.events.PlaylistItemEvent;
+import com.longtailvideo.jwplayer.events.SeekEvent;
+import com.longtailvideo.jwplayer.events.SeekedEvent;
+import com.longtailvideo.jwplayer.events.SetupErrorEvent;
+import com.longtailvideo.jwplayer.events.TimeEvent;
+import com.longtailvideo.jwplayer.events.VisualQualityEvent;
 import com.longtailvideo.jwplayer.events.listeners.AdvertisingEvents;
 import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
-import com.longtailvideo.jwplayer.media.adaptive.QualityLevel;
-import com.longtailvideo.jwplayer.media.adaptive.VisualQuality;
-import com.longtailvideo.jwplayer.media.audio.AudioTrack;
-import com.longtailvideo.jwplayer.media.captions.Caption;
-import com.longtailvideo.jwplayer.media.meta.Metadata;
-import com.longtailvideo.jwplayer.media.playlists.PlaylistItem;
-
 import java.util.List;
 
 /**
@@ -43,7 +59,7 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
         VideoPlayerEvents.OnPauseListener,
         VideoPlayerEvents.OnBufferListener,
         VideoPlayerEvents.OnIdleListener,
-        VideoPlayerEvents.OnErrorListenerV2,
+        VideoPlayerEvents.OnErrorListener,
         VideoPlayerEvents.OnSeekListener,
         VideoPlayerEvents.OnTimeListener,
         VideoPlayerEvents.OnFullscreenListener,
@@ -56,22 +72,19 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
         VideoPlayerEvents.OnLevelsChangedListener,
         VideoPlayerEvents.OnLevelsListener,
         VideoPlayerEvents.OnCaptionsChangedListener,
-        VideoPlayerEvents.OnRelatedCloseListener,
         VideoPlayerEvents.OnControlsListener,
         VideoPlayerEvents.OnDisplayClickListener,
         VideoPlayerEvents.OnMuteListener,
-        VideoPlayerEvents.OnRelatedOpenListener,
-        VideoPlayerEvents.OnRelatedPlayListener,
         VideoPlayerEvents.OnSeekedListener,
         VideoPlayerEvents.OnVisualQualityListener,
-        AdvertisingEvents.OnAdClickListenerV2,
-        AdvertisingEvents.OnAdCompleteListenerV2,
-        AdvertisingEvents.OnAdSkippedListenerV2,
+        AdvertisingEvents.OnAdClickListener,
+        AdvertisingEvents.OnAdCompleteListener,
+        AdvertisingEvents.OnAdSkippedListener,
         AdvertisingEvents.OnAdErrorListener,
-        AdvertisingEvents.OnAdImpressionListenerV2,
-        AdvertisingEvents.OnAdTimeListenerV2,
-        AdvertisingEvents.OnAdPauseListenerV2,
-        AdvertisingEvents.OnAdPlayListenerV2,
+        AdvertisingEvents.OnAdImpressionListener,
+        AdvertisingEvents.OnAdTimeListener,
+        AdvertisingEvents.OnAdPauseListener,
+        AdvertisingEvents.OnAdPlayListener,
         AdvertisingEvents.OnBeforePlayListener,
         AdvertisingEvents.OnBeforeCompleteListener {
 
@@ -95,9 +108,6 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
         jwPlayerView.addOnLevelsListener(this);
         jwPlayerView.addOnCaptionsListListener(this);
         jwPlayerView.addOnCaptionsChangedListener(this);
-        jwPlayerView.addOnRelatedCloseListener(this);
-        jwPlayerView.addOnRelatedOpenListener(this);
-        jwPlayerView.addOnRelatedPlayListener(this);
         jwPlayerView.addOnControlsListener(this);
         jwPlayerView.addOnDisplayClickListener(this);
         jwPlayerView.addOnMuteListener(this);
@@ -127,51 +137,51 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
      */
 
     @Override
-    public void onAudioTracks(List<AudioTrack> audioTracks) {
-        updateOutput("onAudioTracks(List<AudioTrack>)");
+    public void onAudioTracks(AudioTracksEvent audioTracksEvent) {
+
     }
 
     @Override
-    public void onBeforeComplete() {
+    public void onBeforeComplete(BeforeCompleteEvent beforeCompleteEvent) {
         updateOutput("onBeforeComplete()");
     }
 
     @Override
-    public void onBeforePlay() {
+    public void onBeforePlay(BeforePlayEvent beforePlayEvent) {
         updateOutput("onBeforePlay()");
     }
 
     @Override
-    public void onBuffer(PlayerState oldState) {
-        updateOutput("onBuffer(" + oldState + ")");
+    public void onBuffer(BufferEvent bufferEvent) {
+        updateOutput("onBuffer(" + bufferEvent.getOldState() + ")");
     }
 
     @Override
-    public void onCaptionsList(List<Caption> tracks) {
+    public void onCaptionsList(CaptionsListEvent captionsListEvent) {
         updateOutput("onCaptionsList(List<Caption>)");
     }
 
     @Override
-    public void onComplete() {
+    public void onComplete(CompleteEvent completeEvent) {
         updateOutput("onComplete()");
     }
 
     @Override
-    public void onFullscreen(boolean fullscreen) {
-        updateOutput("onFullscreen(" + fullscreen + ")");
+    public void onFullscreen(FullscreenEvent fullscreenEvent) {
+        updateOutput("onFullscreen(" + fullscreenEvent.getFullscreen() + ")");
     }
 
     @Override
-    public void onIdle(PlayerState oldState) {
-        updateOutput("onIdle(" + oldState + ")");
+    public void onIdle(IdleEvent idleEvent) {
+        updateOutput("onIdle(" + idleEvent.getOldState() + ")");
     }
 
     @Override
-    public void onMeta(Metadata meta) {
+    public void onMeta(MetaEvent metaEvent) {
         updateOutput("onMeta(Metadata)");
 
-        if(meta.getId3Metadata().size() > 0) {
-            List<Id3Frame> id3 = meta.getId3Metadata();
+        if(metaEvent.getMetadata().getId3Metadata().size() > 0) {
+            List<Id3Frame> id3 = metaEvent.getMetadata().getId3Metadata();
             for(Id3Frame id3Obj : id3) {
                 if(id3Obj instanceof TextInformationFrame) {
                     TextInformationFrame txxxFrame = (TextInformationFrame)id3Obj;
@@ -187,48 +197,48 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
     }
 
     @Override
-    public void onPause(PlayerState oldState) {
-        updateOutput("onPause(" + oldState + ")");
+    public void onPause(PauseEvent pauseEvent) {
+        updateOutput("onPause(" + pauseEvent.getOldState() + ")");
     }
 
     @Override
-    public void onPlay(PlayerState oldState) {
-        updateOutput("onPlay(" + oldState + ")");
+    public void onPlay(PlayEvent playEvent) {
+        updateOutput("onPlay(" + playEvent.getOldState() + ")");
     }
 
     @Override
-    public void onPlaylistComplete() {
+    public void onPlaylistComplete(PlaylistCompleteEvent playlistCompleteEvent) {
         updateOutput("onPlaylistComplete()");
     }
 
     @Override
-    public void onPlaylistItem(int index, PlaylistItem playlistItem) {
-        updateOutput("onPlaylistItem(" + index + ", PlaylistItem)");
+    public void onPlaylistItem(PlaylistItemEvent playlistItemEvent) {
+        updateOutput("onPlaylistItem(" + playlistItemEvent.getIndex() + ", PlaylistItem)");
     }
 
     @Override
-    public void onPlaylist(List<PlaylistItem> playlist) {
+    public void onPlaylist(PlaylistEvent playlistEvent) {
         updateOutput("onPlaylist(List<PlaylistItem>)");
     }
 
     @Override
-    public void onSeek(int position, int offset) {
-        updateOutput("onSeek(" + position + ", " + offset + ")");
+    public void onSeek(SeekEvent seekEvent) {
+        updateOutput("onSeek(" + seekEvent.getPosition() + ", " + seekEvent.getOffset() + ")");
     }
 
     @Override
-    public void onSetupError(String message) {
-        updateOutput("onSetupError(\"" + message + "\")");
+    public void onSetupError(SetupErrorEvent setupErrorEvent) {
+        updateOutput("onSetupError(\"" + setupErrorEvent.getMessage() + "\")");
     }
 
     @Override
-    public void onTime(long position, long duration) {
+    public void onTime(TimeEvent timeEvent) {
         // Do nothing - this fires several times per second
     }
 
     @Override
-    public void onAdError(String tag, String message) {
-        updateOutput("onAdError(\"" + tag + "\", \"" + message + "\")");
+    public void onAdError(AdErrorEvent adErrorEvent) {
+        updateOutput("onAdError(\"" + adErrorEvent.getTag() + "\", \"" + adErrorEvent.getMessage() + "\")");
     }
 
     @Override
@@ -237,23 +247,23 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
     }
 
     @Override
-    public void onLevelsChanged(int i) {
-        updateOutput("onLevelsChange(" + i + ")");
+    public void onLevelsChanged(LevelsChangedEvent levelsChangedEvent) {
+        updateOutput("onLevelsChange(" + levelsChangedEvent.getCurrentQuality() + ")");
     }
 
     @Override
-    public void onLevels(List<QualityLevel> list) {
+    public void onLevels(LevelsEvent levelsEvent) {
         updateOutput("onLevels(List<QualityLevel>)");
     }
 
     @Override
-    public void onAudioTrackChanged(int i) {
-        updateOutput("onAudioTrackChanged(" + i + ")");
+    public void onAudioTrackChanged(AudioTrackChangedEvent audioTrackChangedEvent) {
+        updateOutput("onAudioTrackChanged(" + audioTrackChangedEvent.getCurrentTrack() + ")");
     }
 
     @Override
-    public void onCaptionsChanged(int i, List<Caption> list) {
-        updateOutput("onCaptionsChanged(" + i + ", List<Caption>)");
+    public void onCaptionsChanged(CaptionsChangedEvent captionsChangedEvent) {
+        updateOutput("onCaptionsChanged(" + captionsChangedEvent.getCurrentTrack() + ", List<Caption>)");
     }
 
     @Override
@@ -293,42 +303,27 @@ public class JWEventHandler implements VideoPlayerEvents.OnSetupErrorListener,
     }
 
     @Override
-    public void onRelatedClose(RelatedCloseEvent relatedCloseEvent) {
-        updateOutput("onRelatedClose(\"" + relatedCloseEvent.getMethod() + "\")");
-    }
-
-    @Override
     public void onControls(ControlsEvent controlsEvent) {
         updateOutput("onControls(\"" + controlsEvent.getControls() + "\")");
     }
 
     @Override
-    public void onDisplayClick() {
+    public void onDisplayClick(DisplayClickEvent displayClickEvent) {
         updateOutput("onDisplayClick(\"" + "displayClick" + "\")");
     }
 
     @Override
-    public void onMute(boolean b) {
-        updateOutput("onMute(\"" + b + "\")");
+    public void onMute(MuteEvent muteEvent) {
+        updateOutput("onMute(\"" + muteEvent.getMute() + "\")");
     }
 
     @Override
-    public void onRelatedOpen(RelatedOpenEvent relatedOpenEvent) {
-        updateOutput("onRelatedOpen(\"" + relatedOpenEvent.getMethod() + "\")");
-    }
-
-    @Override
-    public void onRelatedPlay(RelatedPlayEvent relatedPlayEvent) {
-        updateOutput("onRelatedPlay(\"" + relatedPlayEvent.getAuto() + "\")");
-    }
-
-    @Override
-    public void onSeeked() {
+    public void onSeeked(SeekedEvent seekedEvent) {
         updateOutput("onSeeked(\"" + "seeked" + "\")");
     }
 
     @Override
-    public void onVisualQuality(VisualQuality visualQuality) {
-        updateOutput("onVisualQuality(\"" + visualQuality.getQualityLevel().getLabel() + "\")");
+    public void onVisualQuality(VisualQualityEvent visualQualityEvent) {
+        updateOutput("onVisualQuality(\"" + visualQualityEvent.getQualityLevel().getLabel() + "\")");
     }
 }

--- a/app/src/main/java/com/jwplayer/opensourcedemo/JWPlayerViewExample.java
+++ b/app/src/main/java/com/jwplayer/opensourcedemo/JWPlayerViewExample.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 
 import com.longtailvideo.jwplayer.JWPlayerView;
 import com.longtailvideo.jwplayer.cast.CastManager;
+import com.longtailvideo.jwplayer.events.FullscreenEvent;
 import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
 import com.longtailvideo.jwplayer.media.playlists.PlaylistItem;
 
@@ -113,13 +114,13 @@ public class JWPlayerViewExample extends AppCompatActivity implements VideoPlaye
 	/**
 	 * Handles JW Player going to and returning from fullscreen by hiding the ActionBar
 	 *
-	 * @param fullscreen true if the player is fullscreen
+	 * @param fullscreenEvent Payload that accompanies the onFullscreen() event.
 	 */
 	@Override
-	public void onFullscreen(boolean fullscreen) {
+	public void onFullscreen(FullscreenEvent fullscreenEvent) {
 		ActionBar actionBar = getSupportActionBar();
 		if (actionBar != null) {
-			if (fullscreen) {
+			if (fullscreenEvent.getFullscreen()) {
 				actionBar.hide();
 			} else {
 				actionBar.show();
@@ -127,7 +128,7 @@ public class JWPlayerViewExample extends AppCompatActivity implements VideoPlaye
 		}
 
 		// When going to Fullscreen we want to set fitsSystemWindows="false"
-		mCoordinatorLayout.setFitsSystemWindows(!fullscreen);
+		mCoordinatorLayout.setFitsSystemWindows(!fullscreenEvent.getFullscreen());
 	}
 
 	@Override
@@ -149,4 +150,7 @@ public class JWPlayerViewExample extends AppCompatActivity implements VideoPlaye
 				return super.onOptionsItemSelected(item);
 		}
 	}
+
+
+
 }

--- a/app/src/main/java/com/jwplayer/opensourcedemo/KeepScreenOnHandler.java
+++ b/app/src/main/java/com/jwplayer/opensourcedemo/KeepScreenOnHandler.java
@@ -6,10 +6,14 @@ import android.view.WindowManager;
 import com.longtailvideo.jwplayer.JWPlayerView;
 import com.longtailvideo.jwplayer.core.PlayerState;
 import com.longtailvideo.jwplayer.events.AdCompleteEvent;
+import com.longtailvideo.jwplayer.events.AdErrorEvent;
 import com.longtailvideo.jwplayer.events.AdPauseEvent;
 import com.longtailvideo.jwplayer.events.AdPlayEvent;
 import com.longtailvideo.jwplayer.events.AdSkippedEvent;
+import com.longtailvideo.jwplayer.events.CompleteEvent;
 import com.longtailvideo.jwplayer.events.ErrorEvent;
+import com.longtailvideo.jwplayer.events.PauseEvent;
+import com.longtailvideo.jwplayer.events.PlayEvent;
 import com.longtailvideo.jwplayer.events.listeners.AdvertisingEvents;
 import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
 
@@ -19,11 +23,11 @@ import com.longtailvideo.jwplayer.events.listeners.VideoPlayerEvents;
 public class KeepScreenOnHandler implements VideoPlayerEvents.OnPlayListener,
         VideoPlayerEvents.OnPauseListener,
         VideoPlayerEvents.OnCompleteListener,
-        VideoPlayerEvents.OnErrorListenerV2,
-        AdvertisingEvents.OnAdPlayListenerV2,
-        AdvertisingEvents.OnAdPauseListenerV2,
-        AdvertisingEvents.OnAdCompleteListenerV2,
-        AdvertisingEvents.OnAdSkippedListenerV2,
+        VideoPlayerEvents.OnErrorListener,
+        AdvertisingEvents.OnAdPlayListener,
+        AdvertisingEvents.OnAdPauseListener,
+        AdvertisingEvents.OnAdCompleteListener,
+        AdvertisingEvents.OnAdSkippedListener,
         AdvertisingEvents.OnAdErrorListener {
 
     /**
@@ -52,22 +56,22 @@ public class KeepScreenOnHandler implements VideoPlayerEvents.OnPlayListener,
     }
 
     @Override
-    public void onPlay(PlayerState oldState) {
+    public void onPlay(PlayEvent playEvent) {
         updateWakeLock(true);
     }
 
     @Override
-    public void onPause(PlayerState oldState) {
+    public void onPause(PauseEvent pauseEvent) {
         updateWakeLock(false);
     }
 
     @Override
-    public void onComplete() {
+    public void onComplete(CompleteEvent completeEvent) {
         updateWakeLock(false);
     }
 
     @Override
-    public void onAdError(String tag, String message) {
+    public void onAdError(AdErrorEvent adErrorEvent) {
         updateWakeLock(false);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,13 @@
 buildscript {
 	repositories {
 		jcenter()
-	}
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
+    }
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.2.3'
+		classpath 'com.android.tools.build:gradle:3.1.4'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files
@@ -17,6 +21,9 @@ allprojects {
 		jcenter()
 		maven {
 			url 'https://mvn.jwplayer.com/content/repositories/releases/'
+		}
+		maven {
+			url 'https://maven.google.com/'
 		}
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 28 15:09:18 EST 2016
+#Wed Aug 15 15:13:34 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Updated to use the latest API calls
Hardcoded for SDK 3.1.0, it previously fetched the latest API which would break the code every time there is a significant update.

